### PR TITLE
move ports.ui to 5000

### DIFF
--- a/meta.toml
+++ b/meta.toml
@@ -5,4 +5,3 @@
     volume.data.path = "/app/data"
     volume.user_config.ignore = true
     ports.ui = 5000
-    

--- a/meta.toml
+++ b/meta.toml
@@ -4,5 +4,5 @@
     compose_partial = "snippet.yml"
     volume.data.path = "/app/data"
     volume.user_config.ignore = true
-    ports.ui = 80
+    ports.ui = 5000
     


### PR DESCRIPTION
In many recipes we have moved the platform link ui from port 80 to 5000. Examples:

https://github.com/DigitalShoestringSolutions/TemperatureMonitoring/pull/46/commits/067f6f0212b6a0e10d63ed26b0bbe91838d5f800
https://github.com/DigitalShoestringSolutions/AirQualityMonitoring/pull/20/commits/59e6e180360028da7a8d6e18cb76922dfea61292
https://github.com/DigitalShoestringSolutions/VibrationMonitoring/pull/11/commits/6c5beada4f5ee9fe188977bf12756e9b79551887

Does the port always have to be set in the recipe? Is there a default? This looks like it. If we want to make the default 5000, is this how?